### PR TITLE
feat: Add 'Optimizer' AI tool to the list

### DIFF
--- a/index.html
+++ b/index.html
@@ -4473,6 +4473,19 @@
                 logoUrl: 'https://play-lh.googleusercontent.com/Ftpre95ViU-5eUBb3AermfIAdAThNCNGkIhedL9jD3XbHvHZU1_mSulq1NkfrKK-WN7J'
             },
             { id: 'tool-001', name: 'ChatGPT', description: {it: 'Genera testo, immagini e risponde a domande con ricerca web.', en: 'Generates text, images, and answers questions with web search.'}, category: 'Testo', country: 'USA', website: 'https://chatgpt.com/', isFeatured: true, logoUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/ChatGPT_logo.svg/1024px-ChatGPT_logo.svg.png', recommendationId: 'tool-025' }, 
+            {
+                id: 'tool-optimizer',
+                name: 'Optimizer',
+                description: {
+                    it: 'Realizzato da OpenAI, è specializzato nell\'ottimizzazione dei prompt per ChatGPT 5.',
+                    en: 'Made by OpenAI, it is specialized in optimizing prompts for ChatGPT 5.'
+                },
+                category: 'Testo',
+                country: 'USA',
+                website: 'https://platform.openai.com/chat/edit?models=gpt-5&optimize=true',
+                isFeatured: false,
+                logoUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/ChatGPT_logo.svg/1024px-ChatGPT_logo.svg.png'
+            },
             { id: 'tool-012', name: 'Google Notebook', description: {it: "Permette di creare riassunti audio sulle fonti dell'utente, rispondere a domande e creare mappe mentali.", en: "Allows creating audio summaries from user sources, answering questions, and creating mind maps."}, category: 'Testo', country: 'USA', website: 'https://notebooklm.google.com/', isFeatured: false, logoUrl: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRJbWdW2SCEWfJuDTh5PVxgmqDvXoX5vElJ6s94SZ8Fe1YPzfxzGPuIyE9cBMDswv3qUd4&usqp=CAU', recommendationId: 'tool-021' },  
             { id: 'tool-013', name: 'Grok', description: {it: 'Assistente di ricerca conversazionale con accesso a dati in tempo reale. (Richiede VPN)', en: 'Conversational research assistant with real-time data access. (Requires VPN)'}, category: 'Testo', country: 'USA', website: 'https://grok.com/', isFeatured: true, logoUrl: 'https://i.namu.wiki/i/Wk8b-Vo4qqynLc4pN1T0otG83F383UPI_IR4VthZuZioAxVD_NS6uErIsecLMDK0F0L-KiUjL7xonRz4EwPL2g.webp', recommendationId: 'tool-001' }, 
             { id: 'tool-044', name: 'Perplexity', description: {it: 'Specializzata nella ricerca web, è la migliore AI per trovare informazioni online.', en: 'Specialized in web search, it is the best AI for finding information online.'}, category: 'Testo', country: 'USA', website: 'https://www.perplexity.ai/', isFeatured: false, logoUrl: 'https://images.seeklogo.com/logo-png/51/2/perplexity-ai-logo-png_seeklogo-517845.png', recommendationId: 'tool-001' }, // Perplexity


### PR DESCRIPTION
Adds the 'Optimizer' tool, an American AI by OpenAI specialized in optimizing prompts for ChatGPT 5, to the 'text' category.

The tool's details are:
- Link: https://platform.openai.com/chat/edit?models=gpt-5&optimize=true
- Image: Same as ChatGPT